### PR TITLE
fix: correct transaction label assignment and add fallback for undefined partner

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,8 @@ All notable changes to the WiseTogether project are documented here.
 ## [Unreleased]
 
 ### Added
-- Implemented edit transaction functionality [#5](https://github.com/WiseTogether/wisetogether-web/issues/5)
+- Fixed incorrect label assignment for newly created transactions [#7](https://github.com/WiseTogether/wisetogether-web/issues/7)
+- Added fallback handling for cases where partner is undefined [#8](https://github.com/WiseTogether/wisetogether-web/issues/8)
 
 ---
 
@@ -21,3 +22,7 @@ All notable changes to the WiseTogether project are documented here.
 
 ### Changed
 - Refactored API authentication to use Supabase access tokens [#10](https://github.com/WiseTogether/wisetogether-web/issues/10) ([#20](https://github.com/WiseTogether/wisetogether-web/pull/20))
+
+### Added
+- Implemented edit transaction functionality [#5](https://github.com/WiseTogether/wisetogether-web/issues/5) ([#21](https://github.com/WiseTogether/wisetogether-web/pull/21))
+- Implemented delete transaction functionality [#11](https://github.com/WiseTogether/wisetogether-web/issues/11) ([#21](https://github.com/WiseTogether/wisetogether-web/pull/22))

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -55,3 +55,27 @@ This document outlines the reasoning and technical approach behind selected chan
 
 ---
 
+## Fix: Transaction Labels and Partner Fallback
+**Issues:** [#7](https://github.com/WiseTogether/wisetogether-web/issues/7), [#8](https://github.com/WiseTogether/wisetogether-web/issues/8)
+
+### Problems
+- New transactions are assigned incorrect labels
+- Shared transactions displayed "undefined owes you" when partner name was missing
+
+### Implementation
+1. Fixed transaction form initialization:
+   - Removed hardcoded `setExpenseType('personal')` in `TransactionForm`
+   - Updated `handleAddTransaction` in `Transactions` to set expense type based on active tab
+   - Form now opens with correct tab (shared/personal) based on context
+
+2. Added partner name fallback:
+   - Updated string concatenation in `TransactionRow` to use nullish coalescing
+   - Changed `${partnerProfile?.name} owes you` to `${partnerProfile?.name ?? 'your partner'} owes you`
+   - Ensures consistent display even when partner data is missing
+
+### Notes
+- Improved user experience by maintaining context between views
+- Enhanced error resilience with proper fallbacks
+
+---
+

--- a/src/auth/Register.tsx
+++ b/src/auth/Register.tsx
@@ -19,7 +19,7 @@ function Register() {
         confirmPassword: '',
     });
 
-    const { signUp } = useAuth();
+    const { signUp, apiRequest } = useAuth();
     const navigate = useNavigate();
 
     // Handles changes in the form input fields
@@ -50,7 +50,6 @@ function Register() {
         event.preventDefault();
         setLoading(true);
 
-        const { apiRequest } = useAuth()
         const userApi = createUserApi(apiRequest)
         const sharedAccountApi = createSharedAccountApi(apiRequest)
 

--- a/src/components/transactions/TransactionForm.tsx
+++ b/src/components/transactions/TransactionForm.tsx
@@ -59,7 +59,6 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
                 splitType: 'equal',
                 splitDetails: { 'user1_amount': 0, 'user2_amount': 0 },
             });
-            setExpenseType('personal');
         }
     }, [mode]);
 

--- a/src/components/transactions/TransactionRow.tsx
+++ b/src/components/transactions/TransactionRow.tsx
@@ -61,7 +61,9 @@ const TransactionRow: React.FC<TransactionRowProps> = ({
                 <div className='text-right w-25'>
                     {showSplitDetails && (
                         <p className='text-xs text-gray-400'>
-                            {transaction.userId === session?.user.id ? 'you paid' : `${partnerProfile?.name} paid` || 'your partner paid'}
+                            {transaction.userId === session?.user.id ? 
+                                'you paid' 
+                                : `${partnerProfile?.name ?? 'your partner'} paid`}
                         </p>
                     )}
                     <p>¥ {Number(transaction.amount).toLocaleString()}</p>
@@ -69,7 +71,9 @@ const TransactionRow: React.FC<TransactionRowProps> = ({
                 {showSplitDetails && (
                     <div className='text-left'>
                         <p className='text-xs text-gray-400'>
-                            {transaction.userId !== session?.user.id ? 'you owe' : `${partnerProfile?.name} owes you` || 'your partner owes you'}
+                            {transaction.userId !== session?.user.id
+                                ? 'you owe'
+                                : `${partnerProfile?.name ?? 'your partner'} owes you`}
                         </p>
                         {transaction.userId === session?.user.id 
                             ? <p className='text-emerald-500'>¥ {Number(transaction.splitDetails?.user2_amount).toLocaleString()}</p>

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -28,6 +28,7 @@ const Transactions: React.FC<TransactionsProps> = ({ allTransactions, setAllTran
     }, [allTransactions]);
 
     const handleAddTransaction = () => {
+        setExpenseType(activeTab === 'shared' ? 'shared' : 'personal');
         setModalMode({ type: 'add' });
     };
 


### PR DESCRIPTION
Resolves #7 and #8 

## What Changed

- Removed hardcoded `setExpenseType('personal')` in `TransactionForm`.
- Updated `handleAddTransaction` in `Transactions` to dynamically set the correct expense type based on the selected tab.
- Updated string rendering logic in `TransactionRow` to use a fallback name

## Testing Instructions

1. Create a transaction from the "Shared" tab and verify that it is labeled correctly.
2. Temporarily simulate missing partner profile data and confirm fallback text "your partner owes you" displays correctly.

## Screenshots
![image](https://github.com/user-attachments/assets/9539df7d-1181-4696-8578-2fc7bdb07d8f)
