### PR TITLE
refactor: extract CTA cards from `Dashboard` into a reusable component

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,8 +7,7 @@ All notable changes to the WiseTogether project are documented here.
 ## [Unreleased]
 
 ### Changed
-- Refactored data fetching and state management [#15](https://github.com/WiseTogether/wisetogether-web/issues/15)
-- Memoized expense breakdown calculation and filtered transactions [#18](https://github.com/WiseTogether/wisetogether-web/issues/18) 
+- Extract CTA cards from Dashboard into a reusable component [#17](https://github.com/WiseTogether/wisetogether-web/issues/17)
 
 ---
 
@@ -53,3 +52,11 @@ All notable changes to the WiseTogether project are documented here.
 
 ### Changed
 - Used toast notifications for all key user actions [#14](https://github.com/WiseTogether/wisetogether-web/issues/14) ([#28](https://github.com/WiseTogether/wisetogether-web/pull/28))
+
+---
+
+## [2025-06-11]
+
+### Changed
+- Refactored data fetching and state management [#15](https://github.com/WiseTogether/wisetogether-web/issues/15) ([#29](https://github.com/WiseTogether/wisetogether-web/pull/29))
+- Memoized expense breakdown calculation and filtered transactions [#18](https://github.com/WiseTogether/wisetogether-web/issues/18) ([#29](https://github.com/WiseTogether/wisetogether-web/pull/29))

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -295,3 +295,17 @@ This document outlines the reasoning and technical approach behind selected chan
 - Improved performance and maintainability
 
 ---
+
+## Refactor: Extract CTA Cards from Dashboard
+
+**Issue:** [#17](https://github.com/WiseTogether/wisetogether-web/issues/17)
+
+### Problem
+- `Dashboard.tsx` includes CTA cards markup mixed with other UI, reducing clarity and reusability
+
+### Implementation
+1. Created reusable `CTACard` component with props for icon, text, styling, and click/link handling.
+
+2. Updated `Dashboard` to use `CTACard`, removing duplicate styles and simplifying code.
+
+---

--- a/src/api/sharedAccountApi.ts
+++ b/src/api/sharedAccountApi.ts
@@ -1,5 +1,5 @@
 import type { ApiConfig } from '../lib/baseApiClient'
-import type { sharedAccount } from '../App'
+import type { SharedAccount } from '../types/auth'
 
 export function createSharedAccountApi(apiRequest: <T>(config: ApiConfig) => Promise<T>) {
   return {
@@ -11,8 +11,8 @@ export function createSharedAccountApi(apiRequest: <T>(config: ApiConfig) => Pro
       })
     },
 
-    findSharedAccountByUserId: async (userId: string): Promise<sharedAccount> => {
-      return apiRequest<sharedAccount>({
+    findSharedAccountByUserId: async (userId: string): Promise<SharedAccount> => {
+      return apiRequest<SharedAccount>({
         method: 'GET',
         url: `/shared-accounts/${userId}`,
       })

--- a/src/components/dashboard/CTACard.tsx
+++ b/src/components/dashboard/CTACard.tsx
@@ -1,0 +1,39 @@
+import { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+
+interface CTACardProps {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  linkTo?: string;
+  onClick?: () => void;
+  bgColor?: string;
+  textColor?: string;
+  iconColor?: string;
+}
+
+const CTACard: React.FC<CTACardProps> = ({
+  icon,
+  title,
+  description,
+  linkTo,
+  onClick,
+  bgColor = 'bg-white',
+  textColor = 'text-emerald-500',
+}) => {
+  const cardContent = (
+    <div className={`flex-1 flex flex-col justify-center items-center gap-2 w-xs h-64 shadow-sm ${bgColor} p-6 text-center hover:cursor-pointer hover:scale-105 hover:shadow-lg transition-transform duration-300`}>
+      {icon}
+      <h1 className={`${textColor} text-xl`}>{title}</h1>
+      <p className={`${textColor === 'text-white' ? 'text-white' : 'text-gray-400'} text-sm`}>{description}</p>
+    </div>
+  );
+
+  if (linkTo) {
+    return <Link to={linkTo}>{cardContent}</Link>;
+  }
+
+  return <div onClick={onClick}>{cardContent}</div>;
+};
+
+export default CTACard; 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -2,7 +2,6 @@ import { useState, useMemo } from 'react'
 import { PiUsers } from "react-icons/pi";
 import { RiMoneyCnyCircleLine } from "react-icons/ri";
 import { AiOutlineProfile } from "react-icons/ai";
-import { Link } from 'react-router-dom';
 import InvitationCard from '../components/dashboard/InvitationCard';
 import { useAuth } from '../auth/AuthContext';
 import { createSharedAccountApi } from '../api/sharedAccountApi'
@@ -10,6 +9,7 @@ import PieChart from '../components/dashboard/PieChart';
 import { FadeLoader } from 'react-spinners';
 import { useSharedAccountData } from '../hooks/useSharedAccountData'
 import { useTransactionsData } from '../hooks/useTransactionsData'
+import CTACard from '../components/dashboard/CTACard';
 
 const Dashboard: React.FC = () => {
   const { session, apiRequest } = useAuth()
@@ -95,33 +95,31 @@ const Dashboard: React.FC = () => {
           </div>
 
           <div className='flex p-6 gap-4 items-center justify-center'>
-            {/* Prompt to add an expense */}
-            <Link to='/transactions'>
-              <div className='flex-1 flex flex-col justify-center items-center gap-2 w-xs h-64 shadow-sm bg-white p-6 text-center hover:cursor-pointer hover:scale-105 hover:shadow-lg transition-transform duration-300'>
-                <RiMoneyCnyCircleLine fontSize={50} color={'#10B981'}/>
-                <h1 className='text-emerald-500 text-xl'>Add an expense</h1>
-                <p className='text-gray-400 text-sm'>Add your first expense to get a sense of how things work.</p>
-              </div>
-            </Link>
+            <CTACard
+              icon={<RiMoneyCnyCircleLine fontSize={50} color={'#10B981'}/>}
+              title="Add an expense"
+              description="Add your first expense to get a sense of how things work."
+              linkTo="/transactions"
+            />
 
-            {/* Prompt to create a shared account */}
-            {!isInvitedByPartner && 
-              <div className='flex-1 flex flex-col justify-center items-center gap-2 w-xs h-64 shadow-sm bg-emerald-400 p-6 text-center hover:cursor-pointer hover:scale-105 hover:shadow-lg transition-transform duration-300'
-                onClick={openModal}>
-                <PiUsers fontSize={50} color={'white'}/>
-                <h1 className='text-white text-xl'>Track shared expenses</h1>
-                <p className='text-white text-sm'>Invite your partner to set up a shared account.</p>
-              </div>
-            }
+            {!isInvitedByPartner && (
+              <CTACard
+                icon={<PiUsers fontSize={50} color={'white'}/>}
+                title="Track shared expenses"
+                description="Invite your partner to set up a shared account."
+                onClick={openModal}
+                bgColor="bg-emerald-400"
+                textColor="text-white"
+                iconColor="white"
+              />
+            )}
 
-            {/* Prompt to set up user profile */}
-            <Link to='/settings'>
-              <div className='flex-1 flex flex-col justify-center items-center gap-2 w-xs h-64 shadow-sm bg-white p-6 text-center hover:cursor-pointer hover:scale-105 hover:shadow-lg transition-transform duration-300'>
-                <AiOutlineProfile fontSize={50} color={'#10B981'}/>
-                <h1 className='text-emerald-500 text-xl'>Set up your profile</h1>
-                <p className='text-gray-400 text-sm'>Personalize with a photo and preferences.</p>
-              </div>  
-            </Link>
+            <CTACard
+              icon={<AiOutlineProfile fontSize={50} color={'#10B981'}/>}
+              title="Set up your profile"
+              description="Personalize with a photo and preferences."
+              linkTo="/settings"
+            />
           </div>
         </>
       )}


### PR DESCRIPTION
Resolves #17 

## What Changed

- Added a new reusable `CTACard` component that accepts props for icon, title, description, and custom styling
- Refactored `Dashboard` to use `CTACard` in place of duplicated CTA card code

## Testing Instructions

1. Navigate to the Dashboard
2. Confirm all CTA cards appear and function as before
3. Check for consistent styling across all cards
4. Verify that both click and link-based actions work
