### PR TITLE
refactor: extract auth utils from `AuthContext` and implement caching using `localStorage`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@ All notable changes to the WiseTogether project are documented here.
 ## [Unreleased]
 
 ### Changed
-- Extract CTA cards from Dashboard into a reusable component [#17](https://github.com/WiseTogether/wisetogether-web/issues/17)
+- Extract auth utils from AuthContext and implement caching mechanisms for shared account and partner profile information [#16](https://github.com/WiseTogether/wisetogether-web/issues/16)
 
 ---
 
@@ -60,3 +60,4 @@ All notable changes to the WiseTogether project are documented here.
 ### Changed
 - Refactored data fetching and state management [#15](https://github.com/WiseTogether/wisetogether-web/issues/15) ([#29](https://github.com/WiseTogether/wisetogether-web/pull/29))
 - Memoized expense breakdown calculation and filtered transactions [#18](https://github.com/WiseTogether/wisetogether-web/issues/18) ([#29](https://github.com/WiseTogether/wisetogether-web/pull/29))
+- Extract CTA cards from Dashboard into a reusable component [#17](https://github.com/WiseTogether/wisetogether-web/issues/17) ([#30](https://github.com/WiseTogether/wisetogether-web/pull/30))

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -309,3 +309,28 @@ This document outlines the reasoning and technical approach behind selected chan
 2. Updated `Dashboard` to use `CTACard`, removing duplicate styles and simplifying code.
 
 ---
+
+## Refactor: Extract Auth Utils from AuthContext and Implement Caching Mechanisms
+
+**Issue:** [#16](https://github.com/WiseTogether/wisetogether-web/issues/16)
+
+### Problem
+- Auth utils are embedded in the context code, making it harder to maintain and test.
+- Each session initiates network calls to retrieve shared account and partner profile information, resulting in unnecessary latency and load on the backend.
+
+### Implementation
+1. Caching mechanism
+   - Uses `localStorage` with a 24-hour expiration
+   - Stores both data and timestamp for cache invalidation
+   - Separate cache keys for shared account and partner profile
+
+2. Created  a new `authUtils.ts` file
+   - extracted `extractUserProfile` and `createApiRequest` from AuthContext
+   - updated `AuthContext.tsx` to import utilities from the new location
+
+### Notes
+- Introducing a lightweight caching mechanism results to improved performance and reduced repeated API calls
+- Extraction of utility functions results to better code organization and separation of concerns
+
+---
+

--- a/src/utils/authUtils.ts
+++ b/src/utils/authUtils.ts
@@ -1,0 +1,29 @@
+import { Session } from '@supabase/supabase-js'
+import { UserProfile } from '../types/auth'
+import { ApiConfig, ApiError } from '../lib/baseApiClient'
+import { baseApiClient } from '../lib/baseApiClient'
+
+
+// Extracts user profile information from a Supabase session
+export function extractUserProfile(session: Session | null): UserProfile | null {
+  if (!session?.user) return null
+
+  const metadata = session.user.user_metadata
+  const fullName = metadata?.full_name || metadata?.name || 'User'
+  const displayName = fullName.split(' ')[0] // Get first name
+
+  return {
+    name: displayName,
+    avatarUrl: metadata?.avatar_url || metadata?.picture
+  }
+}
+
+// Creates an API request function that includes the current session's access token
+export function createApiRequest(session: Session | null) {
+  return async <T,>(config: ApiConfig): Promise<T> => {
+    if (!session?.access_token) {
+      throw new ApiError('No access token available', 401)
+    }
+    return baseApiClient<T>({ ...config, accessToken: session.access_token })
+  }
+}


### PR DESCRIPTION
Resolves #16 

## What Changed 

- Implemented lightweight caching for shared account and partner profile data using `localStorage` with 24-hour expiration.
- Cached data includes both payload and timestamp for automatic invalidation.
- Added manual refresh support via `refreshSharedAccount()`.
- Extracted `extractUserProfile` and `createApiRequest` from `AuthContext.tsx` to a new `authUtils.ts` file.
- Updated `AuthContext` to import and use the new utilities.
- Improved performance, reduced redundant API calls, and improved code organization.

## Testing Instructions

1. Verify data is cached after initial load and reused on refresh (check localStorage and network tab).
2. Simulate expiration by editing cache timestamp and confirm data is re-fetched.
3. Call `refreshSharedAccount()` and confirm fresh data is retrieved and cache is updated.
4. Confirm `AuthContext` functionality and login flow remain intact.