### PR TITLE
feat: implement receipt upload and parsing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,8 +6,8 @@ All notable changes to the WiseTogether project are documented here.
 
 ## [Unreleased]
 
-### Changed
-- Extract auth utils from AuthContext and implement caching mechanisms for shared account and partner profile information [#16](https://github.com/WiseTogether/wisetogether-web/issues/16)
+### Added
+- Implemented receipt upload and parsing functionality with loading states [#32](https://github.com/WiseTogether/wisetogether-web/issues/32)
 
 ---
 
@@ -61,3 +61,4 @@ All notable changes to the WiseTogether project are documented here.
 - Refactored data fetching and state management [#15](https://github.com/WiseTogether/wisetogether-web/issues/15) ([#29](https://github.com/WiseTogether/wisetogether-web/pull/29))
 - Memoized expense breakdown calculation and filtered transactions [#18](https://github.com/WiseTogether/wisetogether-web/issues/18) ([#29](https://github.com/WiseTogether/wisetogether-web/pull/29))
 - Extract CTA cards from Dashboard into a reusable component [#17](https://github.com/WiseTogether/wisetogether-web/issues/17) ([#30](https://github.com/WiseTogether/wisetogether-web/pull/30))
+- Extract auth utils from AuthContext and implement caching mechanisms for shared account and partner profile information [#16](https://github.com/WiseTogether/wisetogether-web/issues/16) ([#31](https://github.com/WiseTogether/wisetogether-web/pull/31))

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -334,3 +334,30 @@ This document outlines the reasoning and technical approach behind selected chan
 
 ---
 
+## Feature: Receipt Upload and Parsing
+
+**Issue:** [#32](https://github.com/WiseTogether/wisetogether-web/issues/32)
+
+### Problem
+- Users need a fast and intuitive way to input expense data from physical receipts without manually entering every field. 
+- Manual entry is time-consuming and error-prone, especially for receipts in Japanese.
+
+### Implementation
+
+1. File Upload & Validation
+   - Uses a hidden file input (`accept="image/*"`), triggered by a button.
+   - Validates file type (image/*) and file size (max 5MB).
+   - Displays errors using toast notifications.
+   - Upload button is disabled during upload/parsing.
+
+2. Parsing Flow
+   - Image is sent to the server via FormData (`POST /expenses/parse-receipt`).
+   - Server returns parsed receipt fields
+   - Data is formatted into a transaction object and passed to the form.
+   - Transaction modal opens with pre-filled fields for user confirmation.
+
+#### Notes
+- Future enhancements: receipt preview, batch uploads, stored receipt history
+
+---
+

--- a/src/components/transactions/TransactionForm.tsx
+++ b/src/components/transactions/TransactionForm.tsx
@@ -39,7 +39,7 @@ const TransactionForm: React.FC<TransactionFormProps> = ({
     ];
 
     useEffect(() => {
-        if (mode.type === 'edit' && mode.transaction) {
+        if (mode.transaction) {
             reset({
                 date: mode.transaction.date,
                 amount: mode.transaction.amount,

--- a/src/lib/baseApiClient.ts
+++ b/src/lib/baseApiClient.ts
@@ -23,13 +23,19 @@ export async function baseApiClient<T>({
 }: ApiConfig & { accessToken: string }): Promise<T> {
   try {
     const baseUrl = import.meta.env.VITE_API_BASE_URL
-    const requestBody = data ? { body: JSON.stringify(data) } : {}
+    
+    // Handle FormData differently from JSON data
+    const isFormData = data instanceof FormData
+    const requestBody = data ? {
+      body: isFormData ? data : JSON.stringify(data)
+    } : {}
     
     const response = await fetch(`${baseUrl}${url}`, {
       method,
       headers: {
-        'Content-Type': 'application/json',
-        ...(accessToken && { Authorization: `Bearer ${accessToken}` })
+        // Only set Content-Type for non-FormData requests
+        ...(isFormData ? {} : { 'Content-Type': 'application/json' }),
+        ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
       },
       ...requestBody
     });


### PR DESCRIPTION
Resolves #32 

## What Changed

- Added client-side support for uploading receipt images to auto-fill transaction data.
- Implemented file validation (image type & 5MB size limit).
- Integrated `POST /expenses/parse-receipt` API using `FormData`.
- Shows loading state and toast notifications for success/error.
- Automatically opens the transaction modal with parsed data for user review.

## Testing Instructions

- Go to the transaction page and click "Upload Receipt."
- Select a valid image file (≤ 5MB, JPG/PNG).
- Confirm:
  - "Parsing Receipt..." appears during upload.
  - On success, a modal opens with pre-filled fields.
  - On error (invalid file type/size or bad parsing), a toast message appears.
- Try uploading:
  - A valid Japanese or English receipt
  - An invalid file (e.g., PDF or large image)
  - An unreadable or blank image
- After upload, confirm file input resets and no residual UI bugs exist.

## Screenshots
![image](https://github.com/user-attachments/assets/c38f52fa-20a3-4490-862f-7cee802c750b)
![image](https://github.com/user-attachments/assets/a61e3ea3-2068-4f80-8704-16a583beb169)
![image](https://github.com/user-attachments/assets/e4dab404-941e-4f0e-b00a-8cad24b1af86)
